### PR TITLE
copy missed props if not exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "number-to-words-kg",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Convert a number to words on kyrgyz language.",
   "main": "./src",
   "scripts": {

--- a/src/copyPropsIfNotExist.js
+++ b/src/copyPropsIfNotExist.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/**
+ * Copies missed properties from defaultOptions into options object
+ * @param {object} options 
+ * @param {object} defaultOptions 
+ */
+function copyPropsIfNotExist(options, defaultOptions) {
+	for (var key in defaultOptions) {
+		if (!options.hasOwnProperty(key)) {
+			options[key] = defaultOptions[key];
+			continue;
+		}
+		if (typeof defaultOptions[key] === 'object') {
+			copyPropsIfNotExist(options[key], defaultOptions[key]);
+		}
+	}
+}
+
+module.exports = copyPropsIfNotExist;

--- a/src/toWords.js
+++ b/src/toWords.js
@@ -3,6 +3,7 @@
 var isFinite = require('./isFinite');
 var isSafeNumber = require('./isSafeNumber');
 var getDecimalPart = require('./getDecimalPart');
+var copyPropsIfNotExist = require('./copyPropsIfNotExist');
 var capitalizeFirstLetter = require('./capitalizeFirstLetter');
 
 var TEN = 10;
@@ -55,7 +56,7 @@ var defaultOptions = {
  * @param {number|string} number
  * @returns {string}
  */
-function toWords(number, options) {
+function toWords(number, options = {}) {
     var words = '';
     var num = parseInt(number, 10);
     var decimalPart = getDecimalPart(number);
@@ -72,17 +73,7 @@ function toWords(number, options) {
         );
     }
 
-    // copy default options
-    if (!options || typeof options !== 'object') options = defaultOptions;
-    if (!options.hasOwnProperty('currency')) options.currency = defaultOptions.currency;
-
-	if (!options.hasOwnProperty('showCurrency')) options.showCurrency = defaultOptions.showCurrency;
-    if (!options.showCurrency.hasOwnProperty('integer')) options.showCurrency.integer = defaultOptions.showCurrency.integer;
-    if (!options.showCurrency.hasOwnProperty('fractional')) options.showCurrency.fractional = defaultOptions.showCurrency.fractional;
-
-	if (!options.hasOwnProperty('showNumberParts')) options.showNumberParts = defaultOptions.showNumberParts;
-	if (!options.showNumberParts.hasOwnProperty('integer')) options.showNumberParts.integer = defaultOptions.showNumberParts.integer;
-    if (!options.showNumberParts.hasOwnProperty('fractional')) options.showNumberParts.fractional = defaultOptions.showNumberParts.fractional;
+	copyPropsIfNotExist(options, defaultOptions);
 
     // currency
     if (typeof options.currency === 'string') {


### PR DESCRIPTION
copy missed props in options from defaultOptions if not exist.

example:
var options = { showNumberParts: { integer: false, } };

after calling the function options become:
var options = {
   showNumberParts: { integer: false, fractional: true }, // here integer is still false
   currency: "USD",
   showCurrency: {
        integer: true,
        fractional: true
    }
};
